### PR TITLE
fix(ci): use bash shell for header verification (Issue #20)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Verify standardized headers
+      shell: bash
       run: |
         missing_headers=()
         while IFS= read -r file; do


### PR DESCRIPTION
Ensures consistent execution of the header verification script across all platforms by explicitly specifying the bash shell.