### PR TITLE
fix(server): resolve build failures (Issue #21)

### DIFF
--- a/pharos-server/Cargo.toml
+++ b/pharos-server/Cargo.toml
@@ -30,10 +30,9 @@ base64 = "0.22"
 hex = "0.4"
 rand = "0.8"
 prometheus = { version = "0.13", features = ["process"] }
-
-[dev-dependencies]
-tempfile = "3"
-
 lazy_static = "1.4"
 sysinfo = "0.33"
 warp = "0.3"
+
+[dev-dependencies]
+tempfile = "3"

--- a/pharos-server/src/main.rs
+++ b/pharos-server/src/main.rs
@@ -83,7 +83,7 @@ async fn main() -> anyhow::Result<()> {
             sys.refresh_all();
             
             // Record CPU Usage (average over all CPUs)
-            let cpu_load: f32 = sys.cpus().iter().map(|cpu| cpu.cpu_usage()).sum::<f32>() / sys.cpus().len() as f32;
+            let cpu_load: f32 = sys.cpus().iter().map(|cpu: &sysinfo::Cpu| cpu.cpu_usage()).sum::<f32>() / sys.cpus().len() as f32;
             CPU_USAGE.set(cpu_load as f64);
 
             // Record Memory Usage


### PR DESCRIPTION
This PR fixes compilation errors in the pharos-server backend by:
1. Moving 'warp', 'lazy_static', and 'sysinfo' from dev-dependencies to main dependencies.
2. Adding an explicit type annotation to the CPU usage calculation closure to satisfy the compiler.

Verified via Podman build.