### PR TITLE
feat(security): implement Triple-Tier security model (#49)

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -2,7 +2,7 @@
 
 ## Current Status
 **Phase:** 14 (Pulse & Multi-Tenant Architecture) - IN PROGRESS
-**Active Task:** None
+**Active Task:** Task 14.2 (Issue #49): Engineering: Extend `pharos-server` security model
 **Backlog:** 
 
 ## Recent Completions

--- a/TODO.md
+++ b/TODO.md
@@ -89,6 +89,6 @@ A task is considered complete and may be marked `[x]` only when:
 
 ## Phase 14: Pulse & Multi-Tenant Architecture
 - [x] **Task 14.1 (Issue #47):** Engineering: Implement `pharos-pulse` heartbeat agent in Rust for cross-platform system manager integration (Systemd, SCM, launchd).
-- [ ] **Task 14.2 (Issue #TBD):** Engineering: Extend `pharos-server` security model to support Triple-Tier Security (open, protected, scoped) and Provenance Metadata.
+- [ ] **Task 14.2 (Issue #49):** Engineering: Extend `pharos-server` security model to support Triple-Tier Security (open, protected, scoped) and Provenance Metadata.
 - [ ] **Task 14.3 (Issue #TBD):** Engineering: Develop the `pharos-console` (Dynamic Dashboard & WebMCP/MCP Server) to allow AI-agent management of SSH keys and enrollment tokens. Note: This is separate from the marketing site.
 - [ ] **Task 14.4 (Issue #TBD):** Advocacy: Create multi-tenant documentation, "The YOLO Lab" vs "Locking down the Lab" guides, and `pharos-pulse` installation guides. Include docs on the separation of Marketing vs. Console sites.

--- a/pharos-server/src/lib.rs
+++ b/pharos-server/src/lib.rs
@@ -40,6 +40,8 @@ pub async fn handle_connection(mut socket: TcpStream, storage: Arc<RwLock<dyn St
         id: None,
         authenticated: false,
         peer_addr: peer_addr.clone(),
+        roles: Vec::new(),
+        tier: crate::auth::SecurityTier::Open,
     };
     let mut challenge = vec![0u8; 16];
     OsRng.fill_bytes(&mut challenge);
@@ -97,6 +99,7 @@ pub async fn handle_connection(mut socket: TcpStream, storage: Arc<RwLock<dyn St
                     Command::Auth { public_key, signature } => {
                         if auth_manager.verify(public_key, signature, &challenge_hex) {
                             context.authenticated = true;
+                            context.roles = auth_manager.get_roles(public_key);
                             writer.write_all(b"200:Ok
 ").await?;
                         } else {

--- a/pharos-server/src/middleware.rs
+++ b/pharos-server/src/middleware.rs
@@ -13,15 +13,30 @@
  * ======================================================================== */
 
 use crate::protocol::{Command, ProtocolError};
+use crate::auth::SecurityTier;
 use std::sync::Arc;
 use tracing::info;
 
 /// Contextual information about the current client session.
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone)]
 pub struct ClientContext {
     pub id: Option<String>,
     pub authenticated: bool,
     pub peer_addr: String,
+    pub roles: Vec<String>,
+    pub tier: SecurityTier,
+}
+
+impl Default for ClientContext {
+    fn default() -> Self {
+        Self {
+            id: None,
+            authenticated: false,
+            peer_addr: String::new(),
+            roles: Vec::new(),
+            tier: SecurityTier::Open,
+        }
+    }
 }
 
 /// The action to take after a middleware's pre-processing.
@@ -117,6 +132,55 @@ impl Middleware for ReadOnlyMiddleware {
     }
 }
 
+/// Middleware that enforces Triple-Tier Security based on the server's configured tier.
+pub struct SecurityTierMiddleware {
+    pub default_tier: SecurityTier,
+}
+
+impl Middleware for SecurityTierMiddleware {
+    fn pre_process(&self, command: &mut Command, context: &mut ClientContext) -> Result<MiddlewareAction, ProtocolError> {
+        context.tier = self.default_tier; // Set the tier in the context for other middlewares
+
+        match self.default_tier {
+            SecurityTier::Open => {
+                // Open tier: Read-only access is open, writes require auth (handled in lib.rs)
+                Ok(MiddlewareAction::Continue)
+            }
+            SecurityTier::Protected => {
+                // Protected tier: ALL commands (except auth/status/id/quit) require authentication
+                let is_auth_bypassed = matches!(command,
+                    Command::Status | Command::Id(_) | Command::Auth { .. } | Command::Quit
+                );
+                
+                if !is_auth_bypassed && !context.authenticated {
+                    return Ok(MiddlewareAction::ShortCircuit("401:Authentication required for Protected tier\n".to_string()));
+                }
+                Ok(MiddlewareAction::Continue)
+            }
+            SecurityTier::Scoped => {
+                // Scoped tier: Same as protected, but also enforces roles
+                let is_auth_bypassed = matches!(command,
+                    Command::Status | Command::Id(_) | Command::Auth { .. } | Command::Quit
+                );
+                
+                if !is_auth_bypassed && !context.authenticated {
+                    return Ok(MiddlewareAction::ShortCircuit("401:Authentication required for Scoped tier\n".to_string()));
+                }
+
+                let is_write_command = matches!(command, 
+                    Command::Add(_) | Command::Delete(_) | Command::Change { .. }
+                );
+
+                if is_write_command && !context.roles.contains(&"admin".to_string()) {
+                    return Ok(MiddlewareAction::ShortCircuit("403:Forbidden: Admin role required for write operations\n".to_string()));
+                }
+
+                Ok(MiddlewareAction::Continue)
+            }
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -132,6 +196,7 @@ mod tests {
             id: Some("test".to_string()),
             authenticated: false,
             peer_addr: "127.0.0.1:1234".to_string(),
+            ..Default::default()
         };
 
         let result = chain.pre_process(&mut command, &mut context).unwrap();
@@ -153,6 +218,7 @@ mod tests {
             id: Some("guest".to_string()),
             authenticated: true,
             peer_addr: "127.0.0.1:1234".to_string(),
+            ..Default::default()
         };
 
         let result = chain.pre_process(&mut command, &mut context).unwrap();
@@ -176,6 +242,7 @@ mod tests {
             id: Some("guest".to_string()),
             authenticated: true,
             peer_addr: "127.0.0.1:1234".to_string(),
+            ..Default::default()
         };
 
         let result = chain.pre_process(&mut command, &mut context).unwrap();


### PR DESCRIPTION
- Introduced SecurityTier enum (Open, Protected, Scoped).
- Extended AuthManager to extract roles from key comments.
- Implemented SecurityTierMiddleware to enforce auth and role requirements.
- Updated server to parse PHAROS_SECURITY_TIER env var.
- Passed local unit and integration tests.
